### PR TITLE
image size API

### DIFF
--- a/docs/content/images.adoc
+++ b/docs/content/images.adoc
@@ -21,3 +21,26 @@ saved_state do
   image "logo.png", 20, 20
 end
 ----
+
+== Image Size
+
+Find the width of a image
+
+[source,crystal]
+----
+w = image_width "logo.png"
+----
+
+Find the height of a image
+
+[source,crystal]
+----
+h = image_height "logo.png"
+----
+
+Find the width and height together
+
+[source,crystal]
+----
+w, h = image_size "logo.png"
+----

--- a/examples/image_size.cr
+++ b/examples/image_size.cr
@@ -1,0 +1,6 @@
+require "../src/global_context"
+
+image_file = "../docs/content/static/logo.png"
+puts image_width image_file
+puts image_height image_file
+puts image_size image_file

--- a/src/elements/image.cr
+++ b/src/elements/image.cr
@@ -6,7 +6,7 @@ module Chitra
 
     # :nodoc:
     def draw(cairo_ctx)
-      surface = LibCairo.cairo_image_surface_create_from_png(@path.to_unsafe)
+      surface = Chitra.image_surface(@path)
       LibCairo.cairo_set_source_surface(cairo_ctx, surface, @x, @y)
       LibCairo.cairo_paint(cairo_ctx)
     end
@@ -28,6 +28,35 @@ module Chitra
       idx = add_shape_properties(i)
 
       draw_on_default_surface(@elements[idx])
+    end
+
+    # Get width of the image
+    # ```
+    # ctx = Chitra.new
+    # w = ctx.image_width "logo.png"
+    # ```
+    def image_width(path)
+      surface = Chitra.image_surface(path)
+      LibCairo.cairo_image_surface_get_width(surface)
+    end
+
+    # Get height of the image
+    # ```
+    # ctx = Chitra.new
+    # h = ctx.image_height "logo.png"
+    # ```
+    def image_height(path)
+      surface = Chitra.image_surface(path)
+      LibCairo.cairo_image_surface_get_height(surface)
+    end
+
+    # Get width and height of the image
+    # ```
+    # ctx = Chitra.new
+    # w, h = ctx.image_size "logo.png"
+    # ```
+    def image_size(path)
+      {image_width(path), image_height(path)}
     end
   end
 end

--- a/src/global_context.cr
+++ b/src/global_context.cr
@@ -11,7 +11,8 @@ FUNCS = %w[width height enable_debug fill no_fill stroke
   hyphenation hyphen_char text_align line_height point
   save_state restore_state fill_opacity stroke_opacity
   image new_page group_start group_end composite markup
-  markup_box rainbow rainbow_box
+  markup_box rainbow rainbow_box image_width image_height
+  image_size
 ]
 
 # Define the above global functions

--- a/src/helpers.cr
+++ b/src/helpers.cr
@@ -17,6 +17,16 @@ struct Number
 end
 
 module Chitra
+  @@images = Hash(String, LibCairo::PSurfaceT).new
+
+  def self.image_surface(path)
+    if @@images[path]?.nil?
+      @@images[path] = LibCairo.cairo_image_surface_create_from_png(path.to_unsafe)
+    end
+
+    @@images[path]
+  end
+
   @@resolution = 72 # ppi
 
   def self.resolution


### PR DESCRIPTION
Find image width or height or both together.

```crystal
w = image_width "poster.png"
h = image_height "poster.png"
w, h = image_size "poster.png"
```

Calling image_width or height or size multiple times is optimized by caching the image surface once.

Signed-off-by: Aravinda Vishwanathapura <mail@aravindavk.in>